### PR TITLE
Fix wrong annotation return type hint

### DIFF
--- a/src/Limelight.php
+++ b/src/Limelight.php
@@ -44,7 +44,7 @@ class Limelight
      *
      * @param string $text
      * @param bool $runPlugins
-     * @return Limelight\Classes\LimelightResults
+     * @return Classes\LimelightResults
      */
     public function parse($text, $runPlugins = true)
     {
@@ -63,7 +63,7 @@ class Limelight
      * @param string $text
      * @param array $pluginWhiteList
      * @param bool $suppressEvents
-     * @return Limelight\Classes\LimelightResults
+     * @return Classes\LimelightResults
      */
     public function noParse($text, $pluginWhiteList = ['Romaji'], $suppressEvents = false)
     {

--- a/src/MecabMethods.php
+++ b/src/MecabMethods.php
@@ -8,7 +8,7 @@ trait MecabMethods
      * MeCab parseToNode method. Returns native Limelight node object.
      *
      * @param string $string
-     * @return Limelight\Mecab\Node
+     * @return Mecab\Node
      */
     public function mecabToNode($string)
     {


### PR DESCRIPTION
When the type after the @return tag is not a class name starting with \, it will be indexed from the current namespace as a relative namespace, which is inappropriate, and will not be indexed in PHPSTORM.

This can help to have the correct type hints when using

Before:

![image](https://user-images.githubusercontent.com/31845646/150631200-70adfeea-bb1d-4b8d-a034-8d16b53d7d91.png)

![image](https://user-images.githubusercontent.com/31845646/150631304-5229a98f-6ead-45dd-bfa0-bb4565b8cabd.png)


now:

![image](https://user-images.githubusercontent.com/31845646/150631222-f1915127-8c1e-4491-82bf-59f282e6ae71.png)

![image](https://user-images.githubusercontent.com/31845646/150631272-25611e05-9388-4ba8-b6b7-4f26bc2619c0.png)

**PhpStorm 2021.3.1**